### PR TITLE
VAST Impressions mapped to tracking events

### DIFF
--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -71,12 +71,6 @@ router.get(
               type: "linear",
               start: 0.0,
               duration: ad.duration,
-              identifiers: [
-                {
-                  scheme: "urn:com:example:ads:id",
-                  value: "972c79e1-2363-403e-9287-a0fa4323c389",
-                },
-              ],
               tracking: trackingEvents,
             },
           ],

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -36,8 +36,8 @@ async function getAds(req, manifestType) {
   return await getVideoManifests(finalUrl, manifestType);
 }
 
-function mapAdCreativeSignaling(ad, trackingEvents) {
-  const mapper = new AdCreativeSignalingMapper(ad, trackingEvents);
+function mapAdCreativeSignaling(ad) {
+  const mapper = new AdCreativeSignalingMapper(ad);
   const mappedTrackingEvents = mapper.map();
 
   return mappedTrackingEvents;
@@ -59,7 +59,7 @@ router.get(
     }
     const assetList = { ASSETS: [] };
     ads.forEach((ad) => {
-      const trackingEvents = mapAdCreativeSignaling(ad, ad.trackingEvents);
+      const trackingEvents = mapAdCreativeSignaling(ad);
       assetList.ASSETS.push({
         URI: ad.fileURL,
         DURATION: ad.duration,

--- a/src/trackingEvents/tracking-events.js
+++ b/src/trackingEvents/tracking-events.js
@@ -43,7 +43,7 @@ class CompleteEvent extends TrackingEvent {
 
 class ImpressionEvent extends TrackingEvent {
   constructor(duration, urls) {
-    super(IMPRESSION, duration, urls, 0.0);
+    super(IMPRESSION, duration, urls);
   }
 }
 

--- a/src/utils/vast-parser.js
+++ b/src/utils/vast-parser.js
@@ -25,6 +25,7 @@ async function getVideoManifests(vastUrl, manifestType) {
   if (parsedVast.ads) {
     for (let i = 0; i < parsedVast.ads.length; i++) {
       const ad = parsedVast.ads[i];
+      const { impressionURLTemplates } = ad;
       if (ad.creatives) {
         for (let j = 0; j < ad.creatives.length; j++) {
           const creative = ad.creatives[j];
@@ -41,6 +42,7 @@ async function getVideoManifests(vastUrl, manifestType) {
                   fileURL: mediaFile.fileURL,
                   duration,
                   trackingEvents: creative.trackingEvents,
+                  impressions: impressionURLTemplates,
                 });
               }
             }


### PR DESCRIPTION
Impressions are parsed by vast-client as a list with "id" and "url" attributes.

``` json
"impressionURLTemplates": [
  {
    "id": "ad-1",
    "url": "https://some-url.com/impression-1"
  },
  {
    "id": "ad-2",
    "url": "https://some-url.com/impression-2"
  }
]
```

The impressions were mapped to an impression tracking event with no start time.
ID's are not being handled at the time.