### PR TITLE
Updated AdCreativeSignaling plugin

### DIFF
--- a/hls.js/adCreativeSignalingPlugin.js
+++ b/hls.js/adCreativeSignalingPlugin.js
@@ -1,3 +1,5 @@
+const SUPPORTED_TRACKING_EVENTS = ["start", "firstQuartile", "midpoint", "thirdQuartile", "complete", "progress", "impression"];
+
 class AdSignalingManager {
   constructor(hls) {
     console.log("Initializing AdSignalingManager");
@@ -37,12 +39,14 @@ class AdSignalingManager {
     const currentTime = this.assetPlayer.currentTime;
 
     this.trackingEventsQueue.forEach((event, index) => {
-      const tolerance = 0.75; // time difference tolerance in seconds
-      if (
-        ((Math.abs(currentTime - event.start) <= tolerance) || event?.start === undefined)
-      ) {
-        Promise.all(event.urls.map((url) => this.sendTrackingEvent(url)));
-        this.trackingEventsQueue.splice(index, 1);
+      if (SUPPORTED_TRACKING_EVENTS.includes(event.type)) {
+        const tolerance = 0.75; // time difference tolerance in seconds
+        if (
+          (event?.offset === undefined || (Math.abs(currentTime - event.offset) <= tolerance))
+        ) {
+          Promise.all(event.urls.map((url) => this.sendTrackingEvent(url)));
+          this.trackingEventsQueue.splice(index, 1);
+        }
       }
     });
   };

--- a/public/hls.js/adCreativeSignalingPlugin.js
+++ b/public/hls.js/adCreativeSignalingPlugin.js
@@ -1,3 +1,5 @@
+const SUPPORTED_TRACKING_EVENTS = ["start", "firstQuartile", "midpoint", "thirdQuartile", "complete", "progress", "impression"];
+
 class AdSignalingManager {
   constructor(hls) {
     console.log("Initializing AdSignalingManager");
@@ -37,12 +39,14 @@ class AdSignalingManager {
     const currentTime = this.assetPlayer.currentTime;
 
     this.trackingEventsQueue.forEach((event, index) => {
-      const tolerance = 0.75; // time difference tolerance in seconds
-      if (
-        ((Math.abs(currentTime - event.start) <= tolerance) || event?.start === undefined)
-      ) {
-        Promise.all(event.urls.map((url) => this.sendTrackingEvent(url)));
-        this.trackingEventsQueue.splice(index, 1);
+      if (SUPPORTED_TRACKING_EVENTS.includes(event.type)) {
+        const tolerance = 0.75; // time difference tolerance in seconds
+        if (
+          (event?.offset === undefined || (Math.abs(currentTime - event.offset) <= tolerance))
+        ) {
+          Promise.all(event.urls.map((url) => this.sendTrackingEvent(url)));
+          this.trackingEventsQueue.splice(index, 1);
+        }
       }
     });
   };

--- a/src/trackingEvents/tracking-events.js
+++ b/src/trackingEvents/tracking-events.js
@@ -1,87 +1,85 @@
 const { logger } = require("../utils/logger.js");
 
 const IMPRESSION = "impression";
+const PROGRESS = "progress";
 
 class TrackingEvent {
   constructor(type, duration, urls) {
-   // console.log(">>>TRACKING EVT: ", type)
+    // console.log(">>>TRACKING EVT: ", type)
     this.type = type;
     //this.duration = duration;
     this.urls = urls;
     //this.start = start;
 
-    if (this.type.startsWith("progress")) {
-    
+    if (this.type.startsWith(PROGRESS)) {
       const offsetValue = this.type.split("-")[1];
       if (offsetValue !== null) {
-        this.offset = 
+        this.offset =
           typeof offsetValue === "string" && offsetValue.includes("%")
-          ? (duration * parseFloat(offsetValue.replace("%", ""))) / 100
-          : parseFloat(offsetValue);
-        
-        this.type = "progress";
+            ? (duration * parseFloat(offsetValue.replace("%", ""))) / 100
+            : parseFloat(offsetValue);
 
-        if (isNaN(this.offset) || this.offset < 0 || this.offset > this.duration) {
-            throw new Error(`Invalid start value: ${offset}`);
+        this.type = PROGRESS;
+
+        if (
+          isNaN(this.offset) ||
+          this.offset < 0 ||
+          this.offset > this.duration
+        ) {
+          throw new Error(`Invalid start value: ${offset}`);
         }
       }
-    }
-    else
-    {
-      switch(type)
-      {
-        case "start":
-          this.offset = 0;
-          break;
-          
-        case "firstQuartile":
-          this.offset = duration * 0.25;
-          break;
-
-        case "midpoint":
-          this.offset = duration * 0.5;
-          break;
-
-        case "thirdQuartile":
-          this.offset = duration * 0.75;
-          break;
-
-        case "complete":
-          this.offset = duration;
+    } else {
+      switch (type) {
+      case "start":
+        this.offset = 0;
         break;
 
+      case "firstQuartile":
+        this.offset = duration * 0.25;
+        break;
+
+      case "midpoint":
+        this.offset = duration * 0.5;
+        break;
+
+      case "thirdQuartile":
+        this.offset = duration * 0.75;
+        break;
+
+      case "complete":
+        this.offset = duration;
+        break;
       }
     }
-    
-    
   }
 }
-
-
 
 class AdCreativeSignalingMapper {
   constructor(ad) {
     this.ad = ad;
     console.log(">>>> Ad Tracking", this.ad.trackingEvents);
   }
-  
+
   map() {
     const newTrackingEvents = this.ad.trackingEvents;
-    
-    if(this.ad?.impressions.length > 0)
-      newTrackingEvents[IMPRESSION] = this.ad.impressions.map((impression) => impression.url);
+
+    if (this.ad?.impressions.length > 0)
+      newTrackingEvents[IMPRESSION] = this.ad.impressions.map(
+        (impression) => impression.url
+      );
 
     const trackingEvents = Object.entries(this.ad.trackingEvents)
       .map(([eventType, urls]) => {
         try {
-          const event = new TrackingEvent( eventType, this.ad.duration, urls );
+          const event = new TrackingEvent(eventType, this.ad.duration, urls);
           //console.log(">>> track evt: ", event)
           return event;
         } catch (error) {
           logger.warn(
             `Skipping invalid event: ${eventType}, Error: ${error.message}`
           );
-        
+
           return null;
         }
       })
@@ -93,5 +91,5 @@ class AdCreativeSignalingMapper {
 
 module.exports = {
   AdCreativeSignalingMapper,
-  TrackingEvent
+  TrackingEvent,
 };


### PR DESCRIPTION
Updated plugin to support new Signal event definition ignoring non supported events. 
Supported events: "start", "firstQuartile", "midpoint", "thirdQuartile", "complete", "progress", "impression"